### PR TITLE
READMEにDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,27 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|name|string|null: false|
-|email|string|null: false, add_index :users, :email, unique: true|
+|name|string|null: false, index: ture|
+|email|string|null: false, unique: true|
 |password|string|null: false|
-|password confirmation|string|null: false|
+|password_confirmation|string|null: false|
 
 ### Association
 - has_many :groups_users
 - has_many :groups, through: :groups_users
 - has_many :messages
-- add_index :users, :name
 
 
 ## groupsテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :groups_users
 - has_many :users, through: :groups_users
 - has_many :messages
-- add_index :groups, :group_name
 
 
 
@@ -70,7 +68,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text|
 |image|string|
 |group_id|integer|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -22,3 +22,59 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false, add_index :users, :email, unique: true|
+|password|string|null: false|
+|password confirmation|string|null: false|
+
+### Association
+- has_many :groups, through: :groups_users
+- has_many :messages
+- add_index :users, :name
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+|add_user|string|
+|chat_menber|string|null: false|
+
+### Association
+- has_many :users, through: :groups_users
+- has_many :messages
+- add_index :groups, :group_name
+
+
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|
+|image|string|
+|group_id|integer|
+|user_id|integer|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Things you may want to cover:
 |password confirmation|string|null: false|
 
 ### Association
+- has_many :groups_users
 - has_many :groups, through: :groups_users
 - has_many :messages
 - add_index :users, :name
@@ -43,10 +44,9 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |group_name|string|null: false|
-|add_user|string|
-|chat_menber|string|null: false|
 
 ### Association
+- has_many :groups_users
 - has_many :users, through: :groups_users
 - has_many :messages
 - add_index :groups, :group_name
@@ -70,10 +70,10 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|
+|body|text|null: false|
 |image|string|
-|group_id|integer|
-|user_id|integer|
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group


### PR DESCRIPTION
# what
chat-spaceの実装前にデータベース構成を考えました。
READMEファイルにマークダウン記法で記述しました。
# why
データ同士の関係の明確化と、実装の効率をよくするためです。